### PR TITLE
Fixed misspelled attribute projectname to be project_name.

### DIFF
--- a/{{cookiecutter.app_name}}/build.sbt
+++ b/{{cookiecutter.app_name}}/build.sbt
@@ -1,4 +1,4 @@
-name := "{{cookiecutter.projectname}}"
+name := "{{cookiecutter.project_name}}"
 
 version := "{{cookiecutter.version}}"
 


### PR DESCRIPTION
``` sh
$ cookiecutter  cookiecutter-scala-spark
project_name [My Scala Spark Application]: 
app_name [sparkapp]: 
project_short_description [A Scala Spark Application]: 
jarfile [sparkapp.jar]: 
version [0.0.1]: 
scala_version [2.10.4]: 
org_package [org.something]: 
org_name [Organization]: 
org_website [http://www.somesite.com]: 
Unable to create file 'build.sbt'
Error message: 'dict object' has no attribute 'projectname'
Context: {
    "cookiecutter": {
        "app_name": "sparkapp", 
        "jarfile": "sparkapp.jar", 
        "org_name": "Organization", 
        "org_package": "org.something", 
        "org_website": "http://www.somesite.com", 
        "project_name": "My Scala Spark Application", 
        "project_short_description": "A Scala Spark Application", 
        "scala_version": "2.10.4", 
        "version": "0.0.1"
    }
}
```
