### PR TITLE
Added entryclass attribute to cookiecutter.json.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
   "app_name": "sparkapp",
   "project_short_description":"A Scala Spark Application",
   "jarfile":"sparkapp.jar",
+  "entryclass":"org.something.SparkApp",
   "version":"0.0.1",
   "scala_version":"2.10.4",
   "org_package":"org.something",


### PR DESCRIPTION
``` sh
$ cookiecutter  cookiecutter-scala-spark
project_name [My Scala Spark Application]: 
app_name [sparkapp]: 
project_short_description [A Scala Spark Application]: 
jarfile [sparkapp.jar]: 
version [0.0.1]: 
scala_version [2.10.4]: 
org_package [org.something]: 
org_name [Organization]: 
org_website [http://www.somesite.com]: 
Unable to create file 'bin/run-yarn-cluster.sh'
Error message: 'dict object' has no attribute 'entryclass'
Context: {
    "cookiecutter": {
        "app_name": "sparkapp", 
        "jarfile": "sparkapp.jar", 
        "org_name": "Organization", 
        "org_package": "org.something", 
        "org_website": "http://www.somesite.com", 
        "project_name": "My Scala Spark Application", 
        "project_short_description": "A Scala Spark Application", 
        "scala_version": "2.10.4", 
        "version": "0.0.1"
    }
}
```
